### PR TITLE
让 genrpm.sh 可以简单运行

### DIFF
--- a/rpm/genrpm.sh
+++ b/rpm/genrpm.sh
@@ -38,14 +38,15 @@ do
     esac
 done
 
-: ${version:=2.5.6}
+: ${version:=`date +%Y%m%d`}
+: ${branch:=master}
 : ${format:=tar.gz}
 
 name="shadowsocks-libev"
 spec_name="shadowsocks-libev.spec"
 
 pushd `git rev-parse --show-toplevel`
-git archive "v${version}" --format="${format}" --prefix="${name}-${version}/" -o rpm/SOURCES/"${name}-${version}.${format}"
+git archive "${branch}" --format="${format}" --prefix="${name}-${version}/" -o rpm/SOURCES/"${name}-${version}.${format}"
 pushd rpm
 
 sed -e "s/^\(Version:	\).*$/\1${version}/" \


### PR DESCRIPTION
现在的版本直接执行 genrpm.sh 脚本是会报错， git archive 命令格式有点问题，-v 参数对应的 tag 又都太老