### PR TITLE
Increase host length of server info

### DIFF
--- a/src/obfs/obfs.h
+++ b/src/obfs/obfs.h
@@ -13,7 +13,7 @@
 #define OBFS_HMAC_SHA1_LEN 10
 
 typedef struct {
-    char host[64];
+    char host[256];
     uint16_t port;
     char *param;
     void *g_data;


### PR DESCRIPTION
64 is too small, 256 should be enough

e.g. `313e5987718b346aaf83-f5e825270f29a84f7881423410384342.ssl.cf1.rackcdn.com`